### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ KubeMQ SDKs support list:
 | Node    |  https://github.com/kubemq-io/node-sdk-cookbook |  
 | Go    | https://github.com/kubemq-io/go-sdk-cookbook|  
 
-## Documatation
+## Documentation
 
 Visit our [Extensive KubeMQ Documentation](https://docs.kubemq.io/).
 


### PR DESCRIPTION
Hi, I've was wandering on the GitHub repo and noticed a little typo in README.md. 
KubeMQ looks great, keep up with your great work :)