### PR TITLE
Corrected API port in config

### DIFF
--- a/operations/k8s.yaml
+++ b/operations/k8s.yaml
@@ -48,7 +48,7 @@ metadata:
 data:
   CONFIG: |-
     api:
-      port: 8090
+      port: 8080
     authentication:
       config: ""
       enable: false


### PR DESCRIPTION
In several places in the `k8s.yaml` file the port listing for the API service is `8080`, however in the "CONFIG" section it lists the port as `8090`

This causes port mapping for the API port to fail, as the container is starting the API service on `8090` as requested by the config section.